### PR TITLE
feat: 프로필 생성 API 추가

### DIFF
--- a/src/main/kotlin/com/talk/memberService/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/talk/memberService/config/SecurityConfig.kt
@@ -18,6 +18,7 @@ class SecurityConfig(
     @Bean
     fun filterChain(http: ServerHttpSecurity): SecurityWebFilterChain =
             http {
+                csrf { disable() }
                 authorizeExchange {
                     authorize(anyExchange, hasRole("USER"))
                 }

--- a/src/main/kotlin/com/talk/memberService/oauth2/OAuth2AuthenticatedPrincipalExtension.kt
+++ b/src/main/kotlin/com/talk/memberService/oauth2/OAuth2AuthenticatedPrincipalExtension.kt
@@ -1,0 +1,5 @@
+package com.talk.memberService.oauth2
+
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal
+
+fun OAuth2AuthenticatedPrincipal.subject(): String? = this.getAttribute("sub")

--- a/src/main/kotlin/com/talk/memberService/profile/Profile.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/Profile.kt
@@ -12,6 +12,7 @@ import java.time.Instant
 class Profile(
         @Id
         var id: String? = null,
+        var userId: String,
         var email: String,
         var name: String? = null,
         @CreatedDate
@@ -25,7 +26,7 @@ class Profile(
 ) {
 
     private constructor(builder: Builder) :
-            this(builder.id, builder.email, builder.name, builder.createdAt, builder.createdBy, builder.updatedAt, builder.updatedBy)
+            this(builder.id, builder.userId!!, builder.email, builder.name, builder.createdAt, builder.createdBy, builder.updatedAt, builder.updatedBy)
 
     companion object {
         inline fun profile(block: Builder.() -> Unit) = Builder().apply(block).build()
@@ -43,6 +44,7 @@ class Profile(
 
     class Builder {
         var id: String? = null
+        var userId: String? = null
         var email: String = ""
         var name: String? = ""
         var createdAt: Instant? = null

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileController.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileController.kt
@@ -1,17 +1,19 @@
 package com.talk.memberService.profile
 
+import com.talk.memberService.oauth2.subject
+import org.springframework.http.MediaType
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping(value = ["/member-service"])
-class ProfileController {
-
-    @GetMapping(value = ["/profiles"])
-    suspend fun test(@AuthenticationPrincipal principal: OAuth2AuthenticatedPrincipal) {
+class ProfileController(
+        private val profileService: ProfileService
+) {
+    @PostMapping(value = ["/profiles"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+    suspend fun create(@AuthenticationPrincipal principal: OAuth2AuthenticatedPrincipal, @RequestBody payload: ProfileCreationPayload) {
+        profileService.create(principal.subject(), payload)
     }
 }
 

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileCreationPayload.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileCreationPayload.kt
@@ -1,0 +1,15 @@
+package com.talk.memberService.profile
+
+/**
+ * 프로필 생성 데이터
+ */
+data class ProfileCreationPayload(
+        /**
+         * 이메일
+         */
+        val email: String,
+        /**
+         * 이름
+         */
+        val name: String
+)

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileRepository.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileRepository.kt
@@ -2,4 +2,8 @@ package com.talk.memberService.profile
 
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 
-interface ProfileRepository: CoroutineCrudRepository<Profile, String>
+interface ProfileRepository: CoroutineCrudRepository<Profile, String> {
+    suspend fun countByUserId(userId: String): Int
+
+    suspend fun countByEmail(email: String): Int
+}

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileService.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileService.kt
@@ -1,0 +1,24 @@
+package com.talk.memberService.profile
+
+import com.talk.memberService.profile.Profile.Companion.profile
+import org.springframework.stereotype.Service
+
+@Service
+class ProfileService(
+        private val repository: ProfileRepository
+) {
+    /**
+     * 프로필 생성
+     */
+    suspend fun create(userId: String?, payload: ProfileCreationPayload) {
+        if (userId == null) throw Exception("회원 번호가 존재하지 않습니다")
+        if (payload.name.isEmpty()) throw Exception("이름이 존재하지 않습니다")
+        if (repository.countByUserId(userId) > 0) throw Exception("프로필이 존재합니다")
+        if (repository.countByEmail(payload.email) > 0) throw Exception("프로필이 존재합니다")
+        profile {
+            this.userId = userId
+            this.email = payload.email
+            this.name = payload.name
+        }.run { repository.save(this) }
+    }
+}

--- a/src/main/resources/db/migration/V202304121600__profile.sql
+++ b/src/main/resources/db/migration/V202304121600__profile.sql
@@ -1,0 +1,3 @@
+-- 프로필 테이블
+ALTER TABLE profile
+ADD COLUMN user_id VARCHAR(100) UNIQUE NOT NULL;

--- a/src/test/kotlin/com/talk/memberService/profile/ProfileControllerTests.kt
+++ b/src/test/kotlin/com/talk/memberService/profile/ProfileControllerTests.kt
@@ -1,0 +1,46 @@
+package com.talk.memberService.profile
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import oauth2.Oauth2Constants
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockOpaqueToken
+import org.springframework.test.web.reactive.server.WebTestClient
+
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+class ProfileControllerTests(
+        private val webClient: WebTestClient,
+        private val profileRepository: ProfileRepository
+) : BehaviorSpec({
+
+    fun request(payload: ProfileCreationPayload) = webClient
+            .mutateWith(
+                    mockOpaqueToken().attributes {
+                        it["sub"] = Oauth2Constants.SUBJECT
+                    }.authorities(Oauth2Constants.ROLES)
+            )
+            .post().uri("/member-service/profiles").bodyValue(payload)
+
+    Given("프로필 생성") {
+        When("성공한 경우") {
+            beforeEach {
+                profileRepository.deleteAll()
+            }
+            val payload = ProfileCreationPayload(
+                    "test@test",
+                    "kkk"
+            )
+            Then("status 200") {
+                request(payload).exchange().expectStatus().isOk
+            }
+            Then("프로필 데이터가 존재한다") {
+                request(payload).exchange()
+                profileRepository.countByEmail(payload.email) shouldBe 1
+                profileRepository.count() shouldBe 1
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/talk/memberService/profile/ProfileRepositoryTests.kt
+++ b/src/test/kotlin/com/talk/memberService/profile/ProfileRepositoryTests.kt
@@ -13,13 +13,18 @@ class ProfileRepositoryTests(
 
     Given("프로필 생성 하기") {
         When("프로필 생성 성공한 경우") {
+            beforeEach {
+                repository.deleteAll()
+            }
             val profile = profile {
+                this.userId = "a"
                 this.email = "test@test"
                 this.name = "a"
             }
             Then("id, createdAt, updatedAt 이 존재한다") {
                 repository.save(profile).should {
                     it.id shouldNotBe null
+                    it.userId shouldNotBe null
                     it.createdAt shouldNotBe null
                     it.updatedAt shouldNotBe null
                 }

--- a/src/test/kotlin/oauth2/Oauth2Constants.kt
+++ b/src/test/kotlin/oauth2/Oauth2Constants.kt
@@ -1,0 +1,8 @@
+package oauth2
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+
+object Oauth2Constants {
+    val SUBJECT = "user-id"
+    val ROLES = listOf("ROLE_USER").map { SimpleGrantedAuthority(it) }
+}


### PR DESCRIPTION
## 요약
### API
- method: POST
- url: /member-service/profiles
- authorization: Bearer
- content-type: application/json
#### Request
- body
```jsonc
{
  "email": "이메일",
  "name": "이름" 
}
```
#### Response
- status: 200
