### PR TITLE
feat:프로필 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/talk/memberService/profile/Profile.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/Profile.kt
@@ -14,7 +14,7 @@ class Profile(
         var id: String? = null,
         var userId: String,
         var email: String,
-        var name: String? = null,
+        var name: String,
         @CreatedDate
         var createdAt: Instant? = null,
         @CreatedBy
@@ -26,7 +26,7 @@ class Profile(
 ) {
 
     private constructor(builder: Builder) :
-            this(builder.id, builder.userId!!, builder.email, builder.name, builder.createdAt, builder.createdBy, builder.updatedAt, builder.updatedBy)
+            this(builder.id, builder.userId!!, builder.email, builder.name!!, builder.createdAt, builder.createdBy, builder.updatedAt, builder.updatedBy)
 
     companion object {
         inline fun profile(block: Builder.() -> Unit) = Builder().apply(block).build()

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileController.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileController.kt
@@ -7,10 +7,14 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal
 import org.springframework.web.bind.annotation.*
 
 @RestController
-@RequestMapping(value = ["/member-service"])
+@RequestMapping(value = ["/member-service"], produces = [MediaType.APPLICATION_JSON_VALUE])
 class ProfileController(
         private val profileService: ProfileService
 ) {
+    @GetMapping(value = ["/profiles"])
+    suspend fun getView(@AuthenticationPrincipal principal: OAuth2AuthenticatedPrincipal): ProfileView =
+            profileService.getByUserId(principal.subject()).toView()
+
     @PostMapping(value = ["/profiles"], consumes = [MediaType.APPLICATION_JSON_VALUE])
     suspend fun create(@AuthenticationPrincipal principal: OAuth2AuthenticatedPrincipal, @RequestBody payload: ProfileCreationPayload) {
         profileService.create(principal.subject(), payload)

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileRepository.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileRepository.kt
@@ -2,8 +2,10 @@ package com.talk.memberService.profile
 
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 
-interface ProfileRepository: CoroutineCrudRepository<Profile, String> {
+interface ProfileRepository : CoroutineCrudRepository<Profile, String> {
     suspend fun countByUserId(userId: String): Int
 
     suspend fun countByEmail(email: String): Int
+
+    suspend fun findByUserId(userId: String): Profile?
 }

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileService.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileService.kt
@@ -21,4 +21,12 @@ class ProfileService(
             this.name = payload.name
         }.run { repository.save(this) }
     }
+
+    /**
+     * 회원 ID 기준 프로필 조회
+     */
+    suspend fun getByUserId(userId: String?): Profile {
+        if (userId == null) throw Exception("회원 번호가 존재하지 않습니다")
+        return repository.findByUserId(userId) ?: throw Exception("프로필이 존재하지 않습니다")
+    }
 }

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileView.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileView.kt
@@ -1,0 +1,25 @@
+package com.talk.memberService.profile
+
+/**
+ * 프로필 응답 데이터
+ */
+data class ProfileView(
+        /**
+         * 프로필 id
+         */
+        val id: String,
+        /**
+         * 이메일
+         */
+        val email: String,
+        /**
+         * 이름
+         */
+        val name: String
+)
+
+fun Profile.toView() = ProfileView(
+        id = id!!,
+        email = email,
+        name = name
+)

--- a/src/test/kotlin/com/talk/memberService/profile/api/ProfileCreationApiTests.kt
+++ b/src/test/kotlin/com/talk/memberService/profile/api/ProfileCreationApiTests.kt
@@ -1,5 +1,7 @@
-package com.talk.memberService.profile
+package com.talk.memberService.profile.api
 
+import com.talk.memberService.profile.ProfileCreationPayload
+import com.talk.memberService.profile.ProfileRepository
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import oauth2.Oauth2Constants
@@ -11,7 +13,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 
 @SpringBootTest
 @AutoConfigureWebTestClient
-class ProfileControllerTests(
+class ProfileCreationApiTests(
         private val webClient: WebTestClient,
         private val profileRepository: ProfileRepository
 ) : BehaviorSpec({

--- a/src/test/kotlin/com/talk/memberService/profile/api/ProfileViewApiTests.kt
+++ b/src/test/kotlin/com/talk/memberService/profile/api/ProfileViewApiTests.kt
@@ -1,0 +1,56 @@
+package com.talk.memberService.profile.api
+
+import com.talk.memberService.profile.Profile.Companion.profile
+import com.talk.memberService.profile.ProfileRepository
+import com.talk.memberService.profile.ProfileView
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import oauth2.Oauth2Constants
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockOpaqueToken
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+class ProfileViewApiTests(
+        private val webClient: WebTestClient,
+        private val profileRepository: ProfileRepository
+) : BehaviorSpec({
+
+    fun request() = webClient
+            .mutateWith(
+                    mockOpaqueToken().attributes {
+                        it["sub"] = Oauth2Constants.SUBJECT
+                    }.authorities(Oauth2Constants.ROLES)
+            )
+            .get().uri("/member-service/profiles")
+
+    Given("프로필 조회") {
+        When("성공한 경우") {
+            val email = "test@test"
+            val name = "a"
+            beforeEach {
+                profileRepository.deleteAll()
+                profile{
+                    this.userId = Oauth2Constants.SUBJECT
+                    this.email = email
+                    this.name = name
+                }.run { profileRepository.save(this) }
+            }
+            Then("status 200") {
+                request().exchange().expectStatus().isOk
+            }
+            Then("프로필 데이터가 존재한다") {
+                request().exchange().expectBody<ProfileView>().returnResult().responseBody.shouldNotBeNull().should {
+                    it.email shouldBe email
+                    it.name shouldBe name
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 요약
### API
- method: get
- url: /member-service/profiles
- authorization: Bearer
- content-type: application/json
#### response
- status: 200
- body
``` jsonc
{
  "id": "profile id",
  "email": "이메일",
  "name": "이름"
}
```
### Other
- Profile name 필드 수정: non-nullable
- 테스트 패키지 수정