### PR TITLE
feat: auditAware 추가

### DIFF
--- a/src/main/kotlin/com/talk/memberService/config/R2dbcConfig.kt
+++ b/src/main/kotlin/com/talk/memberService/config/R2dbcConfig.kt
@@ -1,10 +1,26 @@
 package com.talk.memberService.config
 
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.domain.ReactiveAuditorAware
 import org.springframework.data.r2dbc.config.EnableR2dbcAuditing
 import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.ReactiveSecurityContextHolder
+import org.springframework.security.core.context.SecurityContext
 
 @Configuration
 @EnableR2dbcAuditing
 @EnableR2dbcRepositories(basePackages = ["com.talk.memberService"])
-class R2dbcConfig
+class R2dbcConfig {
+
+    @Bean
+    fun customAuditorAware(): ReactiveAuditorAware<String> =
+            ReactiveAuditorAware {
+                ReactiveSecurityContextHolder.getContext()
+                        .map(SecurityContext::getAuthentication)
+                        .filter(Authentication::isAuthenticated)
+                        .map (Authentication::getName)
+            }
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,6 +14,11 @@ spring:
     url: jdbc:postgresql://localhost:5432/member_service
     baseline-on-migrate: true
 
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
 
 
 logging:

--- a/src/main/resources/db/migration/V202304061054__profile.sql
+++ b/src/main/resources/db/migration/V202304061054__profile.sql
@@ -4,8 +4,8 @@ CREATE TABLE profile (
     email varchar(100) UNIQUE NOT NULL,
     name varchar(100) UNIQUE NOT NULL,
     created_at timestamp with time zone DEFAULT NULL,
-    created_by timestamp with time zone DEFAULT NULL,
+    created_by varchar(100) DEFAULT NULL,
     updated_at timestamp with time zone DEFAULT NULL,
-    updated_by timestamp with time zone DEFAULT NULL,
+    updated_by varchar(100) DEFAULT NULL,
     PRIMARY KEY (id)
 );

--- a/src/main/resources/db/migration/V202304141013__friend.sql
+++ b/src/main/resources/db/migration/V202304141013__friend.sql
@@ -4,9 +4,9 @@ CREATE TABLE friend (
     profile_id varchar(100) NOT NULL,
     name varchar(100) NOT NULL,
     created_at timestamp with time zone DEFAULT NULL,
-    created_by timestamp with time zone DEFAULT NULL,
+    created_by varchar(100) DEFAULT NULL,
     updated_at timestamp with time zone DEFAULT NULL,
-    updated_by timestamp with time zone DEFAULT NULL,
+    updated_by varchar(100) DEFAULT NULL,
     PRIMARY KEY (id)
 );
 

--- a/src/test/kotlin/com/talk/memberService/profile/api/ProfileCreationApiTests.kt
+++ b/src/test/kotlin/com/talk/memberService/profile/api/ProfileCreationApiTests.kt
@@ -3,7 +3,9 @@ package com.talk.memberService.profile.api
 import com.talk.memberService.profile.ProfileCreationPayload
 import com.talk.memberService.profile.ProfileRepository
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldNotBe
 import oauth2.Oauth2Constants
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import org.springframework.boot.test.context.SpringBootTest
@@ -40,8 +42,16 @@ class ProfileCreationApiTests(
             }
             Then("프로필 데이터가 존재한다") {
                 request(payload).exchange()
-                profileRepository.countByEmail(payload.email) shouldBe 1
-                profileRepository.count() shouldBe 1
+                profileRepository.findByUserId(Oauth2Constants.SUBJECT).shouldNotBeNull().should {
+                    it.id shouldNotBe null
+                    it.userId shouldNotBe null
+                    it.email shouldNotBe null
+                    it.name shouldNotBe null
+                    it.createdAt shouldNotBe null
+                    it.createdBy shouldNotBe null
+                    it.updatedAt shouldNotBe null
+                    it.updatedBy shouldNotBe null
+                }
             }
         }
     }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,6 +14,11 @@ spring:
     url: jdbc:postgresql://localhost:5432/member_service
     baseline-on-migrate: true
 
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
 
 
 logging:


### PR DESCRIPTION
## 요약
- 인증 받은 회원 ID 를 테이블 `created_by` `updated_by` 에 저장
- profile 이 oas가 아닌 경우, springdocs 비활성화
- migration created_by, updated_by 필드 개선