### PR TITLE
feat: 친구 생성 api & 에러 메시지 처리 로직 추가

### DIFF
--- a/src/main/kotlin/com/talk/memberService/ExceptionTranslator.kt
+++ b/src/main/kotlin/com/talk/memberService/ExceptionTranslator.kt
@@ -1,0 +1,15 @@
+package com.talk.memberService
+
+import com.talk.memberService.error.ErrorResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.server.ResponseStatusException
+
+@RestControllerAdvice
+class ExceptionTranslator {
+
+    @ExceptionHandler(value = [ResponseStatusException::class])
+    fun handleResponseStatusException(e: ResponseStatusException): ResponseEntity<ErrorResponse> =
+            ResponseEntity(ErrorResponse.from(e), e.statusCode)
+}

--- a/src/main/kotlin/com/talk/memberService/error/ErrorResponse.kt
+++ b/src/main/kotlin/com/talk/memberService/error/ErrorResponse.kt
@@ -1,0 +1,17 @@
+package com.talk.memberService.error
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+
+class ErrorResponse private constructor(
+        val status: HttpStatus,
+        val message: String? = null
+) {
+    companion object {
+
+        fun from(e: ResponseStatusException) = ErrorResponse(
+                status = HttpStatus.valueOf(e.statusCode.value()),
+                message = e.reason
+        )
+    }
+}

--- a/src/main/kotlin/com/talk/memberService/friend/FriendController.kt
+++ b/src/main/kotlin/com/talk/memberService/friend/FriendController.kt
@@ -1,0 +1,27 @@
+package com.talk.memberService.friend
+
+import com.talk.memberService.oauth2.subject
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(value = ["/member-service"], produces = [MediaType.APPLICATION_JSON_VALUE])
+class FriendController(
+        private val friendCreationService: FriendCreationService
+) {
+    /**
+     * 친구 생성 API
+     */
+    @PostMapping(value = ["/friends"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+    @ResponseStatus(HttpStatus.CREATED)
+    suspend fun create(@AuthenticationPrincipal principal: OAuth2AuthenticatedPrincipal, @RequestBody payload: FriendCreationPayload): FriendView =
+            friendCreationService.create(principal.subject(), payload).toView()
+
+}

--- a/src/main/kotlin/com/talk/memberService/friend/FriendCreationPayload.kt
+++ b/src/main/kotlin/com/talk/memberService/friend/FriendCreationPayload.kt
@@ -1,0 +1,21 @@
+package com.talk.memberService.friend
+
+/**
+ * 친구 생성 필드 데이터
+ */
+data class FriendCreationPayload(
+        /**
+         * 친구 생성 구분
+         */
+        val type: FriendRegisterType,
+
+        /**
+         * 친구 이메일
+         */
+        val email: String?,
+
+        /**
+         * 친구 이름
+         */
+        val name: String?
+)

--- a/src/main/kotlin/com/talk/memberService/friend/FriendCreationService.kt
+++ b/src/main/kotlin/com/talk/memberService/friend/FriendCreationService.kt
@@ -1,0 +1,31 @@
+package com.talk.memberService.friend
+
+import com.talk.memberService.profile.Profile
+import com.talk.memberService.profile.ProfileService
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+
+@Service
+class FriendCreationService(
+        private val profileService: ProfileService,
+        private val friendService: FriendService
+) {
+    /**
+     * 친구 생성하기
+     */
+
+    suspend fun create(userId: String?, payload: FriendCreationPayload): Friend {
+        val myProfile = profileService.getByUserId(userId)
+        val friendProfile = getFriendProfile(payload)
+        if (friendService.getBySubjectProfileIdAndObjectProfileId(myProfile.id!!, friendProfile.id!!) != null)
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "등록된 친구입니다")
+        return friendService.createBy(myProfile, friendProfile)
+    }
+
+    private suspend fun getFriendProfile(payload: FriendCreationPayload): Profile =
+            when (payload.type) {
+                FriendRegisterType.EMAIL -> profileService.getByEmail(payload.email)
+                else -> throw ResponseStatusException(HttpStatus.BAD_REQUEST, "올바르지 않은 형식입니다")
+            }
+}

--- a/src/main/kotlin/com/talk/memberService/friend/FriendRegisterType.kt
+++ b/src/main/kotlin/com/talk/memberService/friend/FriendRegisterType.kt
@@ -1,0 +1,5 @@
+package com.talk.memberService.friend
+
+enum class FriendRegisterType {
+    EMAIL, NAME
+}

--- a/src/main/kotlin/com/talk/memberService/friend/FriendRepository.kt
+++ b/src/main/kotlin/com/talk/memberService/friend/FriendRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 
 interface FriendRepository: CoroutineCrudRepository<Friend, String> {
     fun findAllBySubjectProfileId(subjectProfileId: String): Flow<Friend>
+
+    suspend fun findBySubjectProfileIdAndObjectProfileId(subjectProfileId: String, objectProfileId: String): Friend?
 }

--- a/src/main/kotlin/com/talk/memberService/friend/FriendService.kt
+++ b/src/main/kotlin/com/talk/memberService/friend/FriendService.kt
@@ -1,5 +1,7 @@
 package com.talk.memberService.friend
 
+import com.talk.memberService.friend.Friend.Companion.friend
+import com.talk.memberService.profile.Profile
 import org.springframework.stereotype.Service
 
 @Service
@@ -8,4 +10,13 @@ class FriendService(
 ) {
 
     fun getBySubjectProfileId(subjectProfileId: String) = repository.findAllBySubjectProfileId(subjectProfileId)
+
+    suspend fun getBySubjectProfileIdAndObjectProfileId(subjectProfileId: String, objectProfileId: String) =
+            repository.findBySubjectProfileIdAndObjectProfileId(subjectProfileId, objectProfileId)
+
+    suspend fun createBy(myProfile: Profile, friendProfile: Profile): Friend = friend {
+        this.subjectProfileId = myProfile.id!!
+        this.objectProfileId = friendProfile.id!!
+        this.name = friendProfile.name
+    }.run { repository.save(this) }
 }

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileRepository.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileRepository.kt
@@ -8,4 +8,6 @@ interface ProfileRepository : CoroutineCrudRepository<Profile, String> {
     suspend fun countByEmail(email: String): Int
 
     suspend fun findByUserId(userId: String): Profile?
+
+    suspend fun findByEmail(email: String): Profile?
 }

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileService.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileService.kt
@@ -31,4 +31,12 @@ class ProfileService(
         if (userId == null) throw ResponseStatusException(HttpStatus.BAD_REQUEST, "회원 번호가 존재하지 않습니다")
         return repository.findByUserId(userId) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "회원 번호가 존재하지 않습니다")
     }
+
+    /**
+     * 이메일 기준 프로필 조회
+     */
+    suspend fun getByEmail(email: String?): Profile {
+        if (email == null) throw ResponseStatusException(HttpStatus.BAD_REQUEST, "올바르지 않은 이메일입니다")
+        return repository.findByEmail(email) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다")
+    }
 }

--- a/src/test/kotlin/com/talk/memberService/friend/api/FriendCreateApiTest.kt
+++ b/src/test/kotlin/com/talk/memberService/friend/api/FriendCreateApiTest.kt
@@ -1,0 +1,162 @@
+package com.talk.memberService.friend.api
+
+import com.talk.memberService.error.ErrorResponse
+import com.talk.memberService.friend.Friend.Companion.friend
+import com.talk.memberService.friend.FriendCreationPayload
+import com.talk.memberService.friend.FriendRegisterType
+import com.talk.memberService.friend.FriendRepository
+import com.talk.memberService.friend.FriendView
+import com.talk.memberService.profile.Profile.Companion.profile
+import com.talk.memberService.profile.ProfileRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.flow.collect
+import oauth2.Oauth2Constants
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+class FriendCreateApiTest(
+        private val webClient: WebTestClient,
+        private val profileRepository: ProfileRepository,
+        private val friendRepository: FriendRepository
+) : BehaviorSpec({
+
+    fun request(payload: FriendCreationPayload) = webClient
+            .mutateWith(
+                    SecurityMockServerConfigurers.mockOpaqueToken().attributes {
+                        it["sub"] = Oauth2Constants.SUBJECT
+                    }.authorities(Oauth2Constants.ROLES)
+            )
+            .post()
+            .uri("/member-service/friends")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(payload)
+
+    Given("친구 추가하기") {
+        When("이메일로 추가하는 경우") {
+            and("이메일이 존재하지 않는 경우") {
+                beforeTest {
+                    profileRepository.deleteAll()
+                    friendRepository.deleteAll()
+                    profile {
+                        userId = Oauth2Constants.SUBJECT
+                        email = "test@test.com"
+                        name = "name"
+                    }.run { profileRepository.save(this) }
+                }
+                Then("status: 400") {
+                    val payload = FriendCreationPayload(
+                            FriendRegisterType.EMAIL, null, null
+                    )
+                    val response = request(payload).exchange()
+                    response.expectBody(ErrorResponse::class.java)
+                            .returnResult().responseBody.shouldNotBeNull().should {
+                                it.status shouldBe HttpStatus.BAD_REQUEST
+                                it.message shouldBe "올바르지 않은 이메일입니다"
+                            }
+
+                }
+            }
+            and("조회시 친구의 프로필이 없는경우") {
+                beforeTest {
+                    profileRepository.deleteAll()
+                    friendRepository.deleteAll()
+                    profile {
+                        userId = Oauth2Constants.SUBJECT
+                        email = "test@test.com"
+                        name = "name"
+                    }.run { profileRepository.save(this) }
+                }
+                Then("status: 400") {
+                    val payload = FriendCreationPayload(
+                            FriendRegisterType.EMAIL, "abc@test.com", null
+                    )
+                    val response = request(payload).exchange()
+                    response.expectBody(ErrorResponse::class.java)
+                            .returnResult().responseBody.shouldNotBeNull().should {
+                                it.status shouldBe HttpStatus.NOT_FOUND
+                                it.message shouldBe "존재하지 않는 회원입니다"
+                            }
+
+                }
+            }
+            and("등록된 친구인 경우") {
+                beforeTest {
+                    profileRepository.deleteAll()
+                    friendRepository.deleteAll()
+                    listOf(
+                            profile {
+                                userId = Oauth2Constants.SUBJECT
+                                email = "test@test.com"
+                                name = "name"
+                            },
+                            profile {
+                                userId = "friend-user-id"
+                                email = "abc@test.com"
+                                name = "abc"
+                            }
+                    ).run { profileRepository.saveAll(this).collect() }
+
+                    val myProfile = profileRepository.findByEmail("test@test.com")!!
+                    val friendProfile = profileRepository.findByEmail("abc@test.com")!!
+                    friend {
+                        subjectProfileId = myProfile.id!!
+                        objectProfileId = friendProfile.id!!
+                        name = friendProfile.name
+                    }.run { friendRepository.save(this) }
+
+                }
+                Then("status: 400") {
+                    val payload = FriendCreationPayload(
+                            FriendRegisterType.EMAIL, "abc@test.com", null
+                    )
+                    val response = request(payload).exchange()
+                    response.expectBody(ErrorResponse::class.java)
+                            .returnResult().responseBody.shouldNotBeNull().should {
+                                it.status shouldBe HttpStatus.BAD_REQUEST
+                                it.message shouldBe "등록된 친구입니다"
+                            }
+                }
+            }
+            and("친구 추가 성공한 경우") {
+                beforeTest {
+                    profileRepository.deleteAll()
+                    friendRepository.deleteAll()
+                    listOf(
+                            profile {
+                                userId = Oauth2Constants.SUBJECT
+                                email = "test@test.com"
+                                name = "name"
+                            },
+                            profile {
+                                userId = "friend-user-id"
+                                email = "abc@test.com"
+                                name = "abc"
+                            }
+                    ).run { profileRepository.saveAll(this).collect() }
+                }
+                Then("status: 201") {
+                    val payload = FriendCreationPayload(
+                            FriendRegisterType.EMAIL, "abc@test.com", null
+                    )
+                    val response = request(payload).exchange()
+                    response.expectStatus().isCreated
+                    response.expectBody(FriendView::class.java)
+                            .returnResult().responseBody.shouldNotBeNull().should {
+                                it.id shouldNotBe null
+                                it.name shouldNotBe null
+                            }
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 요약
- 친구 생성 api 추가

```json
{
  "method": "post",
  "url": "/friends",
  "content-type": "application/json",
  "body": {
    "type": "EMAIL",
    "email": "이메일 (nullable)",
    "name": "name (nullable)"
  },
  "response": {
    "status": "OK",
    "body": {
      "id": "친구 id",
      "name": "친구 이름"
    }
  }
}
```

- 에러메시지 body 추가