### PR TITLE
feat: 채팅, 채팅 참가자 도메인 추가

### DIFF
--- a/src/main/kotlin/com/talk/memberService/chat/Chat.kt
+++ b/src/main/kotlin/com/talk/memberService/chat/Chat.kt
@@ -1,0 +1,62 @@
+package com.talk.memberService.chat
+
+import org.springframework.data.annotation.*
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+/**
+ * 인터넷을 통해, 서로간의 정보를 교환하는행위
+ * chat 관련 도메인들을 관리한다
+ */
+@Table
+class Chat(
+        /**
+         * chat ID
+         */
+        @Id
+        var id: String? = null,
+        /**
+         * 채팅 이미지
+         */
+        var image: String,
+        /**
+         * 생성 날짜
+         */
+        @CreatedDate
+        var createdAt: Instant? = null,
+        /**
+         * 생성한 user id
+         */
+        @CreatedBy
+        var createdBy: String? = null,
+        /**
+         * 수정 날짜
+         */
+        @LastModifiedDate
+        var updatedAt: Instant? = null,
+        /**
+         * 수정 user id
+         */
+        @LastModifiedBy
+        var updatedBy: String? = null
+) {
+
+    private constructor(builder: Builder) :
+            this(builder.id, builder.image!!, builder.createdAt, builder.createdBy, builder.updatedAt, builder.updatedBy)
+
+    companion object {
+        inline fun chat(block: Builder.() -> Unit) = Builder().apply(block).build()
+    }
+
+    class Builder {
+        var id: String? = null
+        var image: String? = null
+        var createdAt: Instant? = null
+        var createdBy: String? = null
+        var updatedAt: Instant? = null
+        var updatedBy: String? = null
+        fun build(): Chat {
+            return Chat(this)
+        }
+    }
+}

--- a/src/main/kotlin/com/talk/memberService/chat/ChatRepository.kt
+++ b/src/main/kotlin/com/talk/memberService/chat/ChatRepository.kt
@@ -1,0 +1,5 @@
+package com.talk.memberService.chat
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+interface ChatRepository: CoroutineCrudRepository<Chat, String>

--- a/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipant.kt
+++ b/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipant.kt
@@ -1,0 +1,72 @@
+package com.talk.memberService.chatParticipant
+
+import org.springframework.data.annotation.*
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+/**
+ * 채팅 참가자
+ *
+ * 참가자들은 개별 맞춤으로 채팅방 설정 가능하다
+ */
+@Table
+class ChatParticipant(
+        /**
+         * 채팅 참가자 ID
+         */
+        @Id
+        var id: String? = null,
+        /**
+         * 챗 ID
+         */
+        var chatId: String,
+        /**
+         * 프로필 ID
+         */
+        var profileId: String,
+        /**
+         * 채팅방 이름
+         */
+        var roomName: String,
+        /**
+         * 생성 날짜
+         */
+        @CreatedDate
+        var createdAt: Instant? = null,
+        /**
+         * 생성한 user id
+         */
+        @CreatedBy
+        var createdBy: String? = null,
+        /**
+         * 수정 날짜
+         */
+        @LastModifiedDate
+        var updatedAt: Instant? = null,
+        /**
+         * 수정 user id
+         */
+        @LastModifiedBy
+        var updatedBy: String? = null
+) {
+    private constructor(builder: Builder) :
+            this(builder.id, builder.chatId!!, builder.profileId!!, builder.roomName!!, builder.createdAt, builder.createdBy, builder.updatedAt, builder.updatedBy)
+
+    companion object {
+        inline fun chatParticipant(block: Builder.() -> Unit) = Builder().apply(block).build()
+    }
+
+    class Builder {
+        var id: String? = null
+        var chatId: String? = null
+        var profileId: String? = null
+        var roomName: String? = null
+        var createdAt: Instant? = null
+        var createdBy: String? = null
+        var updatedAt: Instant? = null
+        var updatedBy: String? = null
+        fun build(): ChatParticipant {
+            return ChatParticipant(this)
+        }
+    }
+}

--- a/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipantRepository.kt
+++ b/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipantRepository.kt
@@ -1,0 +1,5 @@
+package com.talk.memberService.chatParticipant
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+interface ChatParticipantRepository : CoroutineCrudRepository<ChatParticipant, String>

--- a/src/main/resources/db/migration/V202304241155__chat.sql
+++ b/src/main/resources/db/migration/V202304241155__chat.sql
@@ -1,0 +1,11 @@
+-- 채팅 테이블
+CREATE TABLE chat (
+    id UUID DEFAULT gen_random_uuid(),
+    image varchar(255) NOT NULL,
+    created_at timestamp with time zone DEFAULT NULL,
+    created_by varchar(100) DEFAULT NULL,
+    updated_at timestamp with time zone DEFAULT NULL,
+    updated_by varchar(100) DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+

--- a/src/main/resources/db/migration/V202304250002__chatParticipant.sql
+++ b/src/main/resources/db/migration/V202304250002__chatParticipant.sql
@@ -1,0 +1,16 @@
+-- 채팅 참가자 테이블
+CREATE TABLE chat_participant (
+    id UUID DEFAULT gen_random_uuid(),
+    chat_id varchar(100) NOT NULL,
+    profile_id varchar(100) NOT NULL,
+    room_name varchar(255) NOT NULL,
+    created_at timestamp with time zone DEFAULT NULL,
+    created_by varchar(100) DEFAULT NULL,
+    updated_at timestamp with time zone DEFAULT NULL,
+    updated_by varchar(100) DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+
+-- INDEX
+CREATE INDEX idx_chat_participant_chat_id on chat_participant (chat_id);
+CREATE INDEX idx_chat_participant_profile_id on chat_participant (profile_id);

--- a/src/test/kotlin/com/talk/memberService/chat/ChatRepositoryTests.kt
+++ b/src/test/kotlin/com/talk/memberService/chat/ChatRepositoryTests.kt
@@ -1,0 +1,33 @@
+package com.talk.memberService.chat
+
+import com.talk.memberService.chat.Chat.Companion.chat
+import com.talk.memberService.r2dbc.RepositoryTest
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+@RepositoryTest
+class ChatRepositoryTests(
+        private val repository: ChatRepository
+) : BehaviorSpec({
+
+    Given("채팅 생성 하기") {
+        When("채팅 생성 성공한 경우") {
+            beforeEach {
+                repository.deleteAll()
+            }
+            Then("DB 에 채팅 데이터가 존재한다") {
+                val chat = chat {
+                    this.image = "test"
+                }
+                repository.save(chat).should {
+                    it.id shouldNotBe null
+                    it.image shouldBe "test"
+                    it.createdAt shouldNotBe null
+                    it.updatedAt shouldNotBe null
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/talk/memberService/chatParticipant/ChatParticipantRepositoryTests.kt
+++ b/src/test/kotlin/com/talk/memberService/chatParticipant/ChatParticipantRepositoryTests.kt
@@ -1,6 +1,5 @@
 package com.talk.memberService.chatParticipant
 
-import com.talk.memberService.chat.Chat.Companion.chat
 import com.talk.memberService.chatParticipant.ChatParticipant.Companion.chatParticipant
 import com.talk.memberService.r2dbc.RepositoryTest
 import io.kotest.core.spec.style.BehaviorSpec
@@ -9,7 +8,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
 @RepositoryTest
-class ChatParticipantepositoryTests(
+class ChatParticipantRepositoryTests(
         private val repository: ChatParticipantRepository
 ) : BehaviorSpec({
 

--- a/src/test/kotlin/com/talk/memberService/chatParticipant/ChatParticipantepositoryTests.kt
+++ b/src/test/kotlin/com/talk/memberService/chatParticipant/ChatParticipantepositoryTests.kt
@@ -1,0 +1,38 @@
+package com.talk.memberService.chatParticipant
+
+import com.talk.memberService.chat.Chat.Companion.chat
+import com.talk.memberService.chatParticipant.ChatParticipant.Companion.chatParticipant
+import com.talk.memberService.r2dbc.RepositoryTest
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+@RepositoryTest
+class ChatParticipantepositoryTests(
+        private val repository: ChatParticipantRepository
+) : BehaviorSpec({
+
+    Given("채팅 참가자 생성 하기") {
+        When("채팅 참가자 생성 성공한 경우") {
+            beforeEach {
+                repository.deleteAll()
+            }
+            Then("DB 에 채팅 참가자 데이터가 존재한다") {
+                val chat = chatParticipant {
+                    this.chatId = "chat-id"
+                    this.profileId = "profile-id"
+                    this.roomName = "room"
+                }
+                repository.save(chat).should {
+                    it.id shouldNotBe null
+                    it.chatId shouldBe "chat-id"
+                    it.profileId shouldBe "profile-id"
+                    it.roomName shouldBe "room"
+                    it.createdAt shouldNotBe null
+                    it.updatedAt shouldNotBe null
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 요약
### 채팅
```kotlin

import org.springframework.data.annotation.*
import org.springframework.data.relational.core.mapping.Table
import java.time.Instant

/**
 * 인터넷을 통해, 서로간의 정보를 교환하는행위
 * chat 관련 도메인들을 관리한다
 */
@Table
class Chat(
        /**
         * chat ID
         */
        @Id
        var id: String? = null,
        /**
         * 채팅 이미지
         */
        var image: String,
        /**
         * 생성 날짜
         */
        @CreatedDate
        var createdAt: Instant? = null,
        /**
         * 생성한 user id
         */
        @CreatedBy
        var createdBy: String? = null,
        /**
         * 수정 날짜
         */
        @LastModifiedDate
        var updatedAt: Instant? = null,
        /**
         * 수정 user id
         */
        @LastModifiedBy
        var updatedBy: String? = null
)
```
### 채팅 참가자
```kotlin

import org.springframework.data.annotation.*
import org.springframework.data.relational.core.mapping.Table
import java.time.Instant

/**
 * 채팅 참가자
 *
 * 참가자들은 개별 맞춤으로 채팅방 설정 가능하다
 */
@Table
class ChatParticipant(
        /**
         * 채팅 참가자 ID
         */
        @Id
        var id: String? = null,
        /**
         * 챗 ID
         */
        var chatId: String,
        /**
         * 프로필 ID
         */
        var profileId: String,
        /**
         * 채팅방 이름
         */
        var roomName: String,
        /**
         * 생성 날짜
         */
        @CreatedDate
        var createdAt: Instant? = null,
        /**
         * 생성한 user id
         */
        @CreatedBy
        var createdBy: String? = null,
        /**
         * 수정 날짜
         */
        @LastModifiedDate
        var updatedAt: Instant? = null,
        /**
         * 수정 user id
         */
        @LastModifiedBy
        var updatedBy: String? = null
)
```