### PR TITLE
feat: 채팅방  생성 api 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.flywaydb:flyway-core")
 	implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.1.0")
 	implementation("org.springdoc:springdoc-openapi-javadoc:1.6.0")

--- a/src/main/kotlin/com/talk/memberService/ExceptionTranslator.kt
+++ b/src/main/kotlin/com/talk/memberService/ExceptionTranslator.kt
@@ -1,9 +1,11 @@
 package com.talk.memberService
 
 import com.talk.memberService.error.ErrorResponse
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.bind.support.WebExchangeBindException
 import org.springframework.web.server.ResponseStatusException
 
 @RestControllerAdvice
@@ -12,4 +14,8 @@ class ExceptionTranslator {
     @ExceptionHandler(value = [ResponseStatusException::class])
     fun handleResponseStatusException(e: ResponseStatusException): ResponseEntity<ErrorResponse> =
             ResponseEntity(ErrorResponse.from(e), e.statusCode)
+
+    @ExceptionHandler(value = [WebExchangeBindException::class])
+    fun handleConstraintViolationException(e: WebExchangeBindException): ResponseEntity<ErrorResponse> =
+            ResponseEntity(ErrorResponse.from(e), HttpStatus.BAD_REQUEST)
 }

--- a/src/main/kotlin/com/talk/memberService/chat/Chat.kt
+++ b/src/main/kotlin/com/talk/memberService/chat/Chat.kt
@@ -3,6 +3,7 @@ package com.talk.memberService.chat
 import org.springframework.data.annotation.*
 import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
+import java.util.UUID
 
 /**
  * 인터넷을 통해, 서로간의 정보를 교환하는행위
@@ -14,7 +15,7 @@ class Chat(
          * chat ID
          */
         @Id
-        var id: String? = null,
+        var id: UUID? = null,
         /**
          * 채팅 이미지
          */
@@ -49,7 +50,7 @@ class Chat(
     }
 
     class Builder {
-        var id: String? = null
+        var id: UUID? = null
         var image: String? = null
         var createdAt: Instant? = null
         var createdBy: String? = null

--- a/src/main/kotlin/com/talk/memberService/chat/ChatConstant.kt
+++ b/src/main/kotlin/com/talk/memberService/chat/ChatConstant.kt
@@ -1,0 +1,6 @@
+package com.talk.memberService.chat
+
+object ChatConstant {
+    val DEFAULT_CHAT_IMAGE = "/images/chat/room.png"
+    val DEFAULT_CHAT_ROOM_NAME = "그룹 채팅"
+}

--- a/src/main/kotlin/com/talk/memberService/chat/ChatController.kt
+++ b/src/main/kotlin/com/talk/memberService/chat/ChatController.kt
@@ -1,0 +1,28 @@
+package com.talk.memberService.chat
+
+import com.talk.memberService.oauth2.subject
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(value = ["/member-service"], produces = [MediaType.APPLICATION_JSON_VALUE])
+class ChatController(
+        private val chatCreationService: ChatCreationService
+) {
+    /**
+     * 채팅방 생성하기
+     */
+    @PostMapping(value = ["/chats"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+    @ResponseStatus(HttpStatus.CREATED)
+    suspend fun create(@AuthenticationPrincipal principal: OAuth2AuthenticatedPrincipal, @Valid @RequestBody payload: ChatCreationPayload) {
+        chatCreationService.create(principal.subject(), payload)
+    }
+}

--- a/src/main/kotlin/com/talk/memberService/chat/ChatCreationPayload.kt
+++ b/src/main/kotlin/com/talk/memberService/chat/ChatCreationPayload.kt
@@ -1,0 +1,16 @@
+package com.talk.memberService.chat
+
+import jakarta.validation.constraints.NotEmpty
+import java.util.UUID
+
+/**
+ * 채팅방 생성 필드 데이터
+ */
+data class ChatCreationPayload(
+        /**
+         * 친구 ID 리스트
+         */
+        @field:NotEmpty
+        val friendIds: List<UUID> = emptyList()
+)
+

--- a/src/main/kotlin/com/talk/memberService/chat/ChatCreationService.kt
+++ b/src/main/kotlin/com/talk/memberService/chat/ChatCreationService.kt
@@ -1,0 +1,29 @@
+package com.talk.memberService.chat
+
+import com.talk.memberService.chatParticipant.ChatParticipantService
+import com.talk.memberService.friend.FriendService
+import com.talk.memberService.profile.ProfileService
+import kotlinx.coroutines.flow.toList
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+
+@Service
+class ChatCreationService(
+        private val profileService: ProfileService,
+        private val friendService: FriendService,
+        private val chatService: ChatService,
+        private val chatParticipantService: ChatParticipantService
+) {
+    /**
+     * 채팅방 생성하기
+     */
+    suspend fun create(userId: String?, payload: ChatCreationPayload) {
+        val profile = profileService.getByUserId(userId)
+        val friends = friendService.findAllByIdsAndSubjectProfileId(payload.friendIds, profile.id!!).toList()
+        if (payload.friendIds.count() != friends.count()) throw ResponseStatusException(HttpStatus.BAD_REQUEST, "올바르지 않은 친구 정보입니다")
+        val profileIds = friends.map { it.objectProfileId }.plus(profile.id!!)
+        val chat = chatService.create()
+        chatParticipantService.createAllBy(chat.id.toString(), profileIds)
+    }
+}

--- a/src/main/kotlin/com/talk/memberService/chat/ChatRepository.kt
+++ b/src/main/kotlin/com/talk/memberService/chat/ChatRepository.kt
@@ -1,5 +1,6 @@
 package com.talk.memberService.chat
 
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import java.util.*
 
-interface ChatRepository: CoroutineCrudRepository<Chat, String>
+interface ChatRepository: CoroutineCrudRepository<Chat, UUID>

--- a/src/main/kotlin/com/talk/memberService/chat/ChatService.kt
+++ b/src/main/kotlin/com/talk/memberService/chat/ChatService.kt
@@ -1,0 +1,16 @@
+package com.talk.memberService.chat
+
+import com.talk.memberService.chat.Chat.Companion.chat
+import org.springframework.stereotype.Service
+
+@Service
+class ChatService(
+        private val repository: ChatRepository
+) {
+    /**
+     * 채팅 도메인 생성
+     */
+    suspend fun create(): Chat = chat {
+        this.image = ChatConstant.DEFAULT_CHAT_IMAGE
+    }.run { repository.save(this) }
+}

--- a/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipant.kt
+++ b/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipant.kt
@@ -3,6 +3,7 @@ package com.talk.memberService.chatParticipant
 import org.springframework.data.annotation.*
 import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
+import java.util.*
 
 /**
  * 채팅 참가자
@@ -15,7 +16,7 @@ class ChatParticipant(
          * 채팅 참가자 ID
          */
         @Id
-        var id: String? = null,
+        var id: UUID? = null,
         /**
          * 챗 ID
          */
@@ -57,7 +58,7 @@ class ChatParticipant(
     }
 
     class Builder {
-        var id: String? = null
+        var id: UUID? = null
         var chatId: String? = null
         var profileId: String? = null
         var roomName: String? = null

--- a/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipantRepository.kt
+++ b/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipantRepository.kt
@@ -1,5 +1,9 @@
 package com.talk.memberService.chatParticipant
 
+import kotlinx.coroutines.flow.Flow
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import java.util.UUID
 
-interface ChatParticipantRepository : CoroutineCrudRepository<ChatParticipant, String>
+interface ChatParticipantRepository : CoroutineCrudRepository<ChatParticipant, UUID> {
+    fun findAllByChatId(chatId: String): Flow<ChatParticipant>
+}

--- a/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipantService.kt
+++ b/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipantService.kt
@@ -1,0 +1,26 @@
+package com.talk.memberService.chatParticipant
+
+import com.talk.memberService.chat.ChatConstant
+import com.talk.memberService.chatParticipant.ChatParticipant.Companion.chatParticipant
+import kotlinx.coroutines.flow.collect
+import org.springframework.stereotype.Service
+
+@Service
+class ChatParticipantService(
+        private val repository: ChatParticipantRepository
+) {
+    /**
+     * 채팅 참가자 리스트 생성
+     */
+    suspend fun createAllBy(chatId: String, profileIds: List<String>) {
+        profileIds.map { profileId ->
+            chatParticipant {
+                this.chatId = chatId
+                this.profileId = profileId
+                this.roomName = ChatConstant.DEFAULT_CHAT_ROOM_NAME
+            }
+        }.run {
+            repository.saveAll(this)
+        }.collect()
+    }
+}

--- a/src/main/kotlin/com/talk/memberService/error/ErrorResponse.kt
+++ b/src/main/kotlin/com/talk/memberService/error/ErrorResponse.kt
@@ -1,6 +1,7 @@
 package com.talk.memberService.error
 
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.support.WebExchangeBindException
 import org.springframework.web.server.ResponseStatusException
 
 class ErrorResponse private constructor(
@@ -12,6 +13,11 @@ class ErrorResponse private constructor(
         fun from(e: ResponseStatusException) = ErrorResponse(
                 status = HttpStatus.valueOf(e.statusCode.value()),
                 message = e.reason
+        )
+
+        fun from(e: WebExchangeBindException) = ErrorResponse(
+                status = HttpStatus.BAD_REQUEST,
+                message = "올바르지 않은 형식입니다"
         )
     }
 }

--- a/src/main/kotlin/com/talk/memberService/friend/Friend.kt
+++ b/src/main/kotlin/com/talk/memberService/friend/Friend.kt
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
+import java.util.UUID
 
 /**
  * 현재 프로필 과 다른 프로필이 연결되는 도메인
@@ -18,7 +19,7 @@ class Friend(
          * 친구 ID
          */
         @Id
-        var id: String? = null,
+        var id: UUID? = null,
         /**
          * 친구 주체 프로필 ID
          */
@@ -72,7 +73,7 @@ class Friend(
     }
 
     class Builder {
-        var id: String? = null
+        var id: UUID? = null
         var subjectProfileId: String? = null
         var objectProfileId: String? = null
         var name: String? = ""

--- a/src/main/kotlin/com/talk/memberService/friend/FriendRepository.kt
+++ b/src/main/kotlin/com/talk/memberService/friend/FriendRepository.kt
@@ -2,9 +2,12 @@ package com.talk.memberService.friend
 
 import kotlinx.coroutines.flow.Flow
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import java.util.UUID
 
-interface FriendRepository: CoroutineCrudRepository<Friend, String> {
+interface FriendRepository: CoroutineCrudRepository<Friend, UUID> {
     fun findAllBySubjectProfileId(subjectProfileId: String): Flow<Friend>
+
+    fun findAllByIdInAndSubjectProfileId(ids:List<UUID>, subjectProfileId: String): Flow<Friend>
 
     suspend fun findBySubjectProfileIdAndObjectProfileId(subjectProfileId: String, objectProfileId: String): Friend?
 }

--- a/src/main/kotlin/com/talk/memberService/friend/FriendService.kt
+++ b/src/main/kotlin/com/talk/memberService/friend/FriendService.kt
@@ -3,6 +3,7 @@ package com.talk.memberService.friend
 import com.talk.memberService.friend.Friend.Companion.friend
 import com.talk.memberService.profile.Profile
 import org.springframework.stereotype.Service
+import java.util.*
 
 @Service
 class FriendService(
@@ -10,6 +11,9 @@ class FriendService(
 ) {
 
     fun getAllBySubjectProfileId(subjectProfileId: String) = repository.findAllBySubjectProfileId(subjectProfileId)
+
+    fun findAllByIdsAndSubjectProfileId(ids: List<UUID>, subjectProfileId: String) =
+            repository.findAllByIdInAndSubjectProfileId(ids, subjectProfileId)
 
     suspend fun getBySubjectProfileIdAndObjectProfileId(subjectProfileId: String, objectProfileId: String) =
             repository.findBySubjectProfileIdAndObjectProfileId(subjectProfileId, objectProfileId)

--- a/src/main/kotlin/com/talk/memberService/friend/FriendService.kt
+++ b/src/main/kotlin/com/talk/memberService/friend/FriendService.kt
@@ -9,7 +9,7 @@ class FriendService(
         private val repository: FriendRepository
 ) {
 
-    fun getBySubjectProfileId(subjectProfileId: String) = repository.findAllBySubjectProfileId(subjectProfileId)
+    fun getAllBySubjectProfileId(subjectProfileId: String) = repository.findAllBySubjectProfileId(subjectProfileId)
 
     suspend fun getBySubjectProfileIdAndObjectProfileId(subjectProfileId: String, objectProfileId: String) =
             repository.findBySubjectProfileIdAndObjectProfileId(subjectProfileId, objectProfileId)

--- a/src/main/kotlin/com/talk/memberService/friend/FriendView.kt
+++ b/src/main/kotlin/com/talk/memberService/friend/FriendView.kt
@@ -1,10 +1,12 @@
 package com.talk.memberService.friend
 
+import java.util.UUID
+
 /**
  * 친구 응답 데이터
  */
 data class FriendView(
-        val id: String,
+        val id: UUID,
         val name: String
 )
 

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileQueryService.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileQueryService.kt
@@ -23,7 +23,7 @@ class ProfileQueryService(
         }
         if (criteria == null) return builder.build()
         if (criteria.containFriend) {
-            builder.friends(friendService.getBySubjectProfileId(profile.id!!).toList())
+            builder.friends(friendService.getAllBySubjectProfileId(profile.id!!).toList())
         }
         return builder.build()
     }

--- a/src/test/kotlin/com/talk/memberService/chat/api/ChatCreationApiTests.kt
+++ b/src/test/kotlin/com/talk/memberService/chat/api/ChatCreationApiTests.kt
@@ -1,0 +1,133 @@
+package com.talk.memberService.chat.api
+
+import com.talk.memberService.chat.ChatCreationPayload
+import com.talk.memberService.chat.ChatRepository
+import com.talk.memberService.chatParticipant.ChatParticipantRepository
+import com.talk.memberService.error.ErrorResponse
+import com.talk.memberService.friend.Friend.Companion.friend
+import com.talk.memberService.friend.FriendRepository
+import com.talk.memberService.profile.Profile.Companion.profile
+import com.talk.memberService.profile.ProfileRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import oauth2.Oauth2Constants
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpStatus
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockOpaqueToken
+import org.springframework.test.web.reactive.server.WebTestClient
+import java.util.UUID
+
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+class ChatCreationApiTests(
+        private val webClient: WebTestClient,
+        private val profileRepository: ProfileRepository,
+        private val friendRepository: FriendRepository,
+        private val chatRepository: ChatRepository,
+        private val chatParticipantRepository: ChatParticipantRepository
+) : BehaviorSpec({
+
+    fun request(payload: ChatCreationPayload) = webClient
+            .mutateWith(
+                    mockOpaqueToken().attributes {
+                        it["sub"] = Oauth2Constants.SUBJECT
+                    }.authorities(Oauth2Constants.ROLES)
+            )
+            .post().uri("/member-service/chats").bodyValue(payload)
+
+    Given("채팅방 생성") {
+        When("친구 id 가 존재하지 않는 경우") {
+            beforeTest {
+                profileRepository.deleteAll()
+                friendRepository.deleteAll()
+                chatRepository.deleteAll()
+                chatParticipantRepository.deleteAll()
+            }
+            Then("status 400") {
+                val payload = ChatCreationPayload()
+                val response = request(payload).exchange()
+                response.expectBody(ErrorResponse::class.java)
+                        .returnResult().responseBody.shouldNotBeNull().should {
+                            it.status shouldBe HttpStatus.BAD_REQUEST
+                            it.message shouldBe "올바르지 않은 형식입니다"
+                        }
+            }
+        }
+        When("친구 id 리스트가 실제 데이터랑 맞지 않는 경우") {
+            beforeTest {
+                profileRepository.deleteAll()
+                friendRepository.deleteAll()
+                chatRepository.deleteAll()
+                chatParticipantRepository.deleteAll()
+                val myProfile = profile {
+                    userId = Oauth2Constants.SUBJECT
+                    email = "test@test.com"
+                    name = "name"
+                }.run { profileRepository.save(this) }
+                val otherProfile = profile {
+                    userId = "other"
+                    email = "other@test.com"
+                    name = "other"
+                }.run { profileRepository.save(this) }
+                friend {
+                    this.subjectProfileId = myProfile.id!!
+                    this.objectProfileId = otherProfile.id!!
+                    this.name = "친구"
+                }.run { friendRepository.save(this) }
+
+            }
+            Then("status 400") {
+                val payload = ChatCreationPayload(listOf(UUID.randomUUID()))
+                val response = request(payload).exchange()
+                response.expectBody(ErrorResponse::class.java)
+                        .returnResult().responseBody.shouldNotBeNull().should {
+                            it.status shouldBe HttpStatus.BAD_REQUEST
+                            it.message shouldBe "올바르지 않은 친구 정보입니다"
+                        }
+            }
+        }
+        When("채팅방 생성 성공한 경우") {
+            beforeTest {
+                profileRepository.deleteAll()
+                friendRepository.deleteAll()
+                chatRepository.deleteAll()
+                chatParticipantRepository.deleteAll()
+                val myProfile = profile {
+                    userId = Oauth2Constants.SUBJECT
+                    email = "test@test.com"
+                    name = "name"
+                }.run { profileRepository.save(this) }
+                val otherProfile = profile {
+                    userId = "other"
+                    email = "other@test.com"
+                    name = "other"
+                }.run { profileRepository.save(this) }
+                friend {
+                    this.subjectProfileId = myProfile.id!!
+                    this.objectProfileId = otherProfile.id!!
+                    this.name = "친구"
+                }.run { friendRepository.save(this) }
+
+            }
+            Then("status 201") {
+                val profile = profileRepository.findByUserId(Oauth2Constants.SUBJECT)
+                val friends = friendRepository.findAllBySubjectProfileId(profile!!.id!!).map { it.id!! }.toList()
+                val payload = ChatCreationPayload(friends)
+                val response = request(payload).exchange()
+                response.expectStatus().isCreated
+                val chat = chatRepository.findAll().first()
+                chat.id shouldNotBe null
+                val chatParticipants = chatParticipantRepository.findAllByChatId(chat.id.toString()).toList()
+                chatParticipants.size shouldBe 2
+            }
+        }
+    }
+})

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -27,3 +27,8 @@ logging:
     org:
       springframework:
         security: TRACE
+      io:
+        r2dbc:
+          postgresql:
+            QUERY: DEBUG # for queries
+            PARAM: DEBUG # for parameters


### PR DESCRIPTION
## 요약
- 도메인 수정
  - chat
  - chatParticipant
  - friend
- validation 로직 적용
- 채팅방 생성 api 추가
  - 채팅방 생성 친구 id 리스트가 없는 경우: 에러
  - 채팅방 생성 친구 id 리스트 수가 실제 데이터 수랑 맞지 않는 경우: 에러

## api
### request
- method: POST
- url: /chats
- content-type: application/json
- body
```json
{
  "friendIds": []
}
```
### response
- status: 201 created
