### PR TITLE
feat: 프로필 채팅방 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/talk/memberService/chat/ChatCreationService.kt
+++ b/src/main/kotlin/com/talk/memberService/chat/ChatCreationService.kt
@@ -29,6 +29,6 @@ class ChatCreationService(
         val participantCount = profileSequenceIds.size
         if (chatService.existByCombinedParticipantProfileSequenceId(combinedParticipantProfileSequenceId)) throw ResponseStatusException(HttpStatus.BAD_REQUEST, "채팅방이 이미 존재합니다")
         val chat = chatService.create(combinedParticipantProfileSequenceId, participantCount)
-        chatParticipantService.createAllBy(chat.id.toString(), profileSequenceIds)
+        chatParticipantService.createAllBy(chat.id!!, profileSequenceIds)
     }
 }

--- a/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipant.kt
+++ b/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipant.kt
@@ -20,7 +20,7 @@ class ChatParticipant(
         /**
          * 챗 ID
          */
-        var chatId: String,
+        var chatId: UUID,
         /**
          * 프로필 숫자열 ID
          */
@@ -59,7 +59,7 @@ class ChatParticipant(
 
     class Builder {
         var id: UUID? = null
-        var chatId: String? = null
+        var chatId: UUID? = null
         var profileSequenceId: Long? = null
         var roomName: String? = null
         var createdAt: Instant? = null

--- a/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipantService.kt
+++ b/src/main/kotlin/com/talk/memberService/chatParticipant/ChatParticipantService.kt
@@ -1,9 +1,10 @@
 package com.talk.memberService.chatParticipant
 
-import com.talk.memberService.chat.ChatConstant
 import com.talk.memberService.chatParticipant.ChatParticipant.Companion.chatParticipant
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import org.springframework.stereotype.Service
+import java.util.*
 
 @Service
 class ChatParticipantService(
@@ -12,7 +13,7 @@ class ChatParticipantService(
     /**
      * 채팅 참가자 리스트 생성
      */
-    suspend fun createAllBy(chatId: String, profileSequenceIds: List<Long>) {
+    suspend fun createAllBy(chatId: UUID, profileSequenceIds: List<Long>) {
         profileSequenceIds.map { profileSequenceId ->
             chatParticipant {
                 this.chatId = chatId

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileChatDto.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileChatDto.kt
@@ -1,0 +1,11 @@
+package com.talk.memberService.profile
+
+import java.util.UUID
+
+data class ProfileChatDto (
+    val id: UUID,
+    val sequenceId: Long,
+    val roomName: String?,
+    val image: String,
+    val profileSequenceIds: List<Long>
+)

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileChatView.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileChatView.kt
@@ -1,0 +1,16 @@
+package com.talk.memberService.profile
+
+import java.util.*
+
+data class ProfileChatView(
+        val id: UUID,
+        val roomName: String,
+        val image: String
+)
+
+
+fun ProfileChatDto.toView() = ProfileChatView(
+        id = this.id,
+        roomName = this.roomName!!,
+        image = this.image
+)

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileController.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileController.kt
@@ -1,6 +1,8 @@
 package com.talk.memberService.profile
 
 import com.talk.memberService.oauth2.subject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import org.springframework.http.MediaType
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal
@@ -20,6 +22,11 @@ class ProfileController(
     @PostMapping(value = ["/profiles"], consumes = [MediaType.APPLICATION_JSON_VALUE])
     suspend fun create(@AuthenticationPrincipal principal: OAuth2AuthenticatedPrincipal, @RequestBody payload: ProfileCreationPayload) {
         profileService.create(principal.subject(), payload)
+    }
+
+    @GetMapping(value = ["/profile/chats"])
+    suspend fun getAllWithChatViews(@AuthenticationPrincipal principal: OAuth2AuthenticatedPrincipal): Flow<ProfileChatView> {
+        return profileQueryService.getAllWithChats(principal.subject()).map(ProfileChatDto::toView)
     }
 }
 

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileQueryService.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileQueryService.kt
@@ -2,6 +2,8 @@ package com.talk.memberService.profile
 
 import com.talk.memberService.friend.FriendService
 import com.talk.memberService.profile.ProfileView.Companion.profileViewBuilder
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
@@ -27,4 +29,22 @@ class ProfileQueryService(
         }
         return builder.build()
     }
+
+    /**
+     * 프로필의 채팅방을 조회한다
+     * 채팅방 참가자가 이름을 설정하지 않은 경우
+     * 자신의 이름을 제외한 참가자 아이디를 문자열로 생성한다 (구분자 ,)
+     */
+    suspend fun getAllWithChats(userId: String?): Flow<ProfileChatDto> =
+            profileService.getAllWithChatsByUserId(userId).map { chat ->
+                if (chat.roomName != null) return@map chat
+                val roomName = chat.profileSequenceIds.minus(chat.sequenceId)
+                        .createRoomNameBySequenceIds()
+                chat.copy(roomName = roomName)
+            }
+
+    private suspend fun List<Long>.createRoomNameBySequenceIds(): String =
+            profileService.getAllBySequenceIds(this).toList()
+                    .joinToString(separator = ",") { it.name }
+
 }

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileRepository.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileRepository.kt
@@ -1,6 +1,7 @@
 package com.talk.memberService.profile
 
 import kotlinx.coroutines.flow.Flow
+import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import java.util.UUID
 
@@ -14,4 +15,16 @@ interface ProfileRepository : CoroutineCrudRepository<Profile, UUID> {
     suspend fun findByEmail(email: String): Profile?
 
     fun findAllByIdIn(ids: List<String>): Flow<Profile>
+
+    @Query(value =
+    "SELECT p.id AS id, p.sequence_id as sequence_id, cp.room_name AS room_name, c.image AS image, STRING_TO_ARRAY(c.combined_participant_profile_sequence_id, ',') AS profile_sequence_ids " +
+            "FROM profile p " +
+            "INNER JOIN chat_participant cp " +
+            "ON p.sequence_id = cp.profile_sequence_id " +
+            "INNER JOIN chat c " +
+            "ON cp.chat_id = c.id " +
+            "WHERE p.user_id = $1")
+    fun findAllWithChatsByUserId(userId: String): Flow<ProfileChatDto>
+
+    fun findAllBySequenceIdIn(sequenceIds: List<Long>): Flow<Profile>
 }

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileService.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileService.kt
@@ -48,4 +48,17 @@ class ProfileService(
     fun getAllByIds(ids: List<String>): Flow<Profile> =
             repository.findAllByIdIn(ids)
 
+    /**
+     * 유저 id를 기준, 프로필 정보와 관련된 채팅방 정보 리스트 조회
+     */
+    fun getAllWithChatsByUserId(userId: String?): Flow<ProfileChatDto> {
+        if (userId == null) throw Exception("회원 번호가 존재하지 않습니다")
+        return repository.findAllWithChatsByUserId(userId)
+    }
+
+    /**
+     * 프로필 순차 ID 기준 리스트 조회
+     */
+    fun getAllBySequenceIds(sequenceIds: List<Long>): Flow<Profile> =
+            repository.findAllBySequenceIdIn(sequenceIds)
 }

--- a/src/main/resources/db/migration/V202304272204__chatParticipant.sql
+++ b/src/main/resources/db/migration/V202304272204__chatParticipant.sql
@@ -1,0 +1,19 @@
+-- 테이블 제거
+DROP TABLE chat_participant;
+
+-- 채팅 참가자 테이블
+CREATE TABLE chat_participant (
+    id UUID DEFAULT gen_random_uuid(),
+    chat_id UUID NOT NULL,
+    profile_sequence_id integer NOT NULL,
+    room_name varchar(255),
+    created_at timestamp with time zone DEFAULT NULL,
+    created_by varchar(100) DEFAULT NULL,
+    updated_at timestamp with time zone DEFAULT NULL,
+    updated_by varchar(100) DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+
+-- INDEX
+CREATE INDEX idx_chat_participant_chat_id on chat_participant (chat_id);
+CREATE INDEX idx_chat_participant_profile_sequence_id on chat_participant (profile_sequence_id);

--- a/src/test/kotlin/com/talk/memberService/chat/api/ChatCreationApiTests.kt
+++ b/src/test/kotlin/com/talk/memberService/chat/api/ChatCreationApiTests.kt
@@ -176,7 +176,7 @@ class ChatCreationApiTests(
                 }.run { friendRepository.save(this) }
 
                 chatParticipant {
-                    this.chatId = "1"
+                    this.chatId = UUID.randomUUID()
                     this.roomName = "a"
                     this.profileSequenceId = -1
                 }.run { chatParticipantRepository.save(this) }

--- a/src/test/kotlin/com/talk/memberService/chatParticipant/ChatParticipantRepositoryTests.kt
+++ b/src/test/kotlin/com/talk/memberService/chatParticipant/ChatParticipantRepositoryTests.kt
@@ -6,6 +6,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import java.util.UUID
 
 @RepositoryTest
 class ChatParticipantRepositoryTests(
@@ -14,18 +15,19 @@ class ChatParticipantRepositoryTests(
 
     Given("채팅 참가자 생성 하기") {
         When("채팅 참가자 생성 성공한 경우") {
+            val uuid = UUID.randomUUID()
             beforeEach {
                 repository.deleteAll()
             }
             Then("DB 에 채팅 참가자 데이터가 존재한다") {
                 val chat = chatParticipant {
-                    this.chatId = "chat-id"
+                    this.chatId = uuid
                     this.profileSequenceId = 1
                     this.roomName = "room"
                 }
                 repository.save(chat).should {
                     it.id shouldNotBe null
-                    it.chatId shouldBe "chat-id"
+                    it.chatId shouldBe uuid
                     it.profileSequenceId shouldBe 1
                     it.roomName shouldBe "room"
                     it.createdAt shouldNotBe null

--- a/src/test/kotlin/com/talk/memberService/profile/api/ProfileChatViewApiTests.kt
+++ b/src/test/kotlin/com/talk/memberService/profile/api/ProfileChatViewApiTests.kt
@@ -1,0 +1,149 @@
+package com.talk.memberService.profile.api
+
+import com.talk.memberService.chat.Chat
+import com.talk.memberService.chat.ChatRepository
+import com.talk.memberService.chatParticipant.ChatParticipant
+import com.talk.memberService.chatParticipant.ChatParticipantRepository
+import com.talk.memberService.friend.FriendRepository
+import com.talk.memberService.profile.Profile
+import com.talk.memberService.profile.Profile.Companion.profile
+import com.talk.memberService.profile.ProfileChatView
+import com.talk.memberService.profile.ProfileRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.collect
+import oauth2.Oauth2Constants
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+class ProfileChatViewApiTests(
+        private val webClient: WebTestClient,
+        private val profileRepository: ProfileRepository,
+        private val friendRepository: FriendRepository,
+        private val chatRepository: ChatRepository,
+        private val chatParticipantRepository: ChatParticipantRepository
+) : BehaviorSpec({
+
+    fun request() = webClient
+            .mutateWith(
+                    SecurityMockServerConfigurers.mockOpaqueToken().attributes {
+                        it["sub"] = Oauth2Constants.SUBJECT
+                    }.authorities(Oauth2Constants.ROLES)
+            )
+            .get().uri { builder ->
+                builder.path("/member-service/profile/chats")
+                builder.build()
+            }
+
+    suspend fun createChats(profiles: List<Profile>, roomName: String? = null) {
+        val profileSequenceIds = profiles.map { it.sequenceId }
+        val chat = Chat.chat {
+            this.image = "a"
+            this.participantCount = profiles.size
+            this.combinedParticipantProfileSequenceId = profileSequenceIds.joinToString(",")
+        }.run { chatRepository.save(this) }
+        profileSequenceIds.map { profileSequenceId ->
+            ChatParticipant.chatParticipant {
+                this.chatId = chat.id!!
+                this.roomName = roomName
+                this.profileSequenceId = profileSequenceId
+            }
+        }.run { chatParticipantRepository.saveAll(this) }.collect()
+    }
+
+    Given("프로필 기준 채팅창 리스트 조회") {
+        When("채팅방 참가자가 방 이름을 설정한 경우") {
+            beforeTest {
+                profileRepository.deleteAll()
+                friendRepository.deleteAll()
+                chatRepository.deleteAll()
+                chatParticipantRepository.deleteAll()
+                val profile1 = profile {
+                    this.userId = Oauth2Constants.SUBJECT
+                    this.sequenceId = 1
+                    this.email = "user@test"
+                    this.name = "user"
+                }.run { profileRepository.save(this) }
+
+                val profile2 = profile {
+                    this.userId = "b"
+                    this.sequenceId = 2
+                    this.email = "b@test"
+                    this.name = "b"
+                }.run { profileRepository.save(this) }
+
+                val profile3 = profile {
+                    this.userId = "c"
+                    this.sequenceId = 3
+                    this.email = "c@test"
+                    this.name = "c"
+                }.run { profileRepository.save(this) }
+
+                createChats(listOf(profile1, profile2), "a")
+                createChats(listOf(profile1, profile3), "a")
+                createChats(listOf(profile2, profile3), "a")
+            }
+            Then("status: 200 Ok") {
+                val exchanged = request().exchange()
+                exchanged.expectStatus().isOk
+                exchanged.expectBodyList(ProfileChatView::class.java).returnResult().responseBody.shouldNotBeNull().should { chats ->
+                    chats.filter { it.roomName == "a" }.size shouldBe 2
+                }
+            }
+        }
+
+        When("채팅방 참가자들이 친구가 없고, 방 이름 설정 안한 경우") {
+            beforeTest {
+                profileRepository.deleteAll()
+                friendRepository.deleteAll()
+                chatRepository.deleteAll()
+                chatParticipantRepository.deleteAll()
+                val profile1 = profile {
+                    this.userId = Oauth2Constants.SUBJECT
+                    this.sequenceId = 1
+                    this.email = "user@test"
+                    this.name = "user"
+                }.run { profileRepository.save(this) }
+
+                val profile2 = profile {
+                    this.userId = "b"
+                    this.sequenceId = 2
+                    this.email = "b@test"
+                    this.name = "b"
+                }.run { profileRepository.save(this) }
+
+                val profile3 = profile {
+                    this.userId = "c"
+                    this.sequenceId = 3
+                    this.email = "c@test"
+                    this.name = "c"
+                }.run { profileRepository.save(this) }
+
+                val profile4 = profile {
+                    this.userId = "d"
+                    this.sequenceId = 4
+                    this.email = "d@test"
+                    this.name = "d"
+                }.run { profileRepository.save(this) }
+
+                createChats(listOf(profile1, profile2, profile3))
+                createChats(listOf(profile1, profile3, profile4))
+                createChats(listOf(profile2, profile3))
+            }
+            Then("status: 200 Ok, 방 이름은 ',' 으로 구분된다") {
+                val exchanged = request().exchange()
+                exchanged.expectStatus().isOk
+                exchanged.expectBodyList(ProfileChatView::class.java).returnResult().responseBody.shouldNotBeNull()
+                        .should { chats ->
+                            chats.filter { it.roomName.contains(",")}.size shouldBe 2
+                        }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 테이블
### chat_participant
- chat_id 필드 타입 수정 (uuid)
## API
### Request
- method: GET
- url: /profile/chats
- content-type: application/json
### Response
- status: 200 ok
- body
```jsonc
[..., {
  "id": "채팅방 id",
  "roomName": "채팅방 이름",
  "image": "채팅방 이미지",
}]
```