### PR TITLE
refactor: 프로필 채팅방 조회 API 개선

### DIFF
--- a/src/main/kotlin/com/talk/memberService/profile/ProfileQueryService.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileQueryService.kt
@@ -1,10 +1,9 @@
 package com.talk.memberService.profile
 
+import com.talk.memberService.friend.Friend
 import com.talk.memberService.friend.FriendService
 import com.talk.memberService.profile.ProfileView.Companion.profileViewBuilder
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.*
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
@@ -34,17 +33,28 @@ class ProfileQueryService(
      * 프로필의 채팅방을 조회한다
      * 채팅방 참가자가 이름을 설정하지 않은 경우
      * 자신의 이름을 제외한 참가자 아이디를 문자열로 생성한다 (구분자 ,)
+     * 참가자중 자신의 친구는 친구의 이름으로 문자열을 생성한다
      */
-    suspend fun getAllWithChats(userId: String?): Flow<ProfileChatDto> =
-            profileService.getAllWithChatsByUserId(userId).map { chat ->
-                if (chat.roomName != null) return@map chat
-                val roomName = chat.profileSequenceIds.minus(chat.sequenceId)
-                        .createRoomNameBySequenceIds()
-                chat.copy(roomName = roomName)
-            }
+    suspend fun getAllWithChats(userId: String?): Flow<ProfileChatDto> {
+        val profile = profileService.getByUserId(userId)
+        val friends = friendService.getAllBySubjectProfileSequenceId(profile.sequenceId!!).toList()
+        return profileService.getAllWithChatsByUserId(userId).map { chat ->
+            if (chat.roomName != null) return@map chat
+            val roomName = chat.profileSequenceIds.minus(chat.sequenceId)
+                    .createRoomNameBySequenceIds(friends)
+            chat.copy(roomName = roomName)
+        }
+    }
 
-    private suspend fun List<Long>.createRoomNameBySequenceIds(): String =
-            profileService.getAllBySequenceIds(this).toList()
-                    .joinToString(separator = ",") { it.name }
-
+    private suspend fun List<Long>.createRoomNameBySequenceIds(friends: List<Friend>): String {
+        val participantFriends = friends.filter { this.contains(it.objectProfileSequenceId) }
+        val remainParticipants = this.minus(participantFriends.map { it.objectProfileSequenceId }.toSet())
+        val friendNames = participantFriends.map { it.name }
+        if (remainParticipants.isEmpty()) {
+            return friendNames.joinToString(separator = ",")
+        }
+        return profileService.getAllBySequenceIds(remainParticipants).map { it.name }.run {
+            merge(this, friendNames.asFlow())
+        }.toList().joinToString(separator = ",")
+    }
 }


### PR DESCRIPTION
## 요약 
- 방이름 생성시, 참가자중 자신의 친구인 경우, 친구의 이름으로 설정