### PR TITLE
feat: 채팅방 단일 조회 api 추가

### DIFF
--- a/src/main/kotlin/com/talk/memberService/profile/ProfileChatController.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileChatController.kt
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal
 import org.springframework.web.bind.annotation.*
+import java.util.UUID
 
 @RestController
 @RequestMapping(value = ["/member-service/profile"], produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -31,7 +32,12 @@ class ProfileChatController(
      * 프로필 기준 채팅방 조회하기
      */
     @GetMapping(value = ["/chats"])
-    suspend fun getAll(@AuthenticationPrincipal principal: OAuth2AuthenticatedPrincipal): Flow<ProfileChatView> {
+    suspend fun getViews(@AuthenticationPrincipal principal: OAuth2AuthenticatedPrincipal): Flow<ProfileChatView> {
         return profileQueryService.getAllWithChats(principal.subject()).map(ProfileChatDto::toView)
+    }
+
+    @GetMapping(value = ["/chats/{chatId}"])
+    suspend fun getView(@PathVariable chatId: UUID, @AuthenticationPrincipal principal: OAuth2AuthenticatedPrincipal): ProfileChatView {
+        return profileQueryService.getWithChat(principal.subject(), chatId).toDetailView()
     }
 }

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileChatDto.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileChatDto.kt
@@ -7,5 +7,6 @@ data class ProfileChatDto (
     val sequenceId: Long,
     val roomName: String?,
     val image: String,
+    val participantCount: Int,
     val profileSequenceIds: List<Long>
 )

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileChatView.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileChatView.kt
@@ -1,16 +1,25 @@
 package com.talk.memberService.profile
 
+import com.talk.memberService.chat.ChatConstant
 import java.util.*
 
 data class ProfileChatView(
         val id: UUID,
         val roomName: String,
-        val image: String
+        val image: String,
+        val participantCount: Int
 )
-
 
 fun ProfileChatDto.toView() = ProfileChatView(
         id = this.id,
         roomName = this.roomName!!,
-        image = this.image
+        image = this.image,
+        participantCount = this.participantCount
+)
+
+fun ProfileChatDto.toDetailView() = ProfileChatView(
+        id = this.id,
+        roomName = this.roomName ?: ChatConstant.DEFAULT_CHAT_ROOM_NAME,
+        image = this.image,
+        participantCount = this.participantCount
 )

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileQueryService.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileQueryService.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.*
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
+import java.util.*
 
 @Service
 class ProfileQueryService(
@@ -45,6 +46,12 @@ class ProfileQueryService(
             chat.copy(roomName = roomName)
         }
     }
+
+    /**
+     * 채팅방 단일 조회
+     */
+    suspend fun getWithChat(userId: String?, chatId: UUID): ProfileChatDto =
+            profileService.getWithChatsByUserIdAndChatId(userId, chatId)
 
     private suspend fun List<Long>.createRoomNameBySequenceIds(friends: List<Friend>): String {
         val participantFriends = friends.filter { this.contains(it.objectProfileSequenceId) }

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileRepository.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileRepository.kt
@@ -17,7 +17,7 @@ interface ProfileRepository : CoroutineCrudRepository<Profile, UUID> {
     fun findAllByIdIn(ids: List<String>): Flow<Profile>
 
     @Query(value =
-    "SELECT p.id AS id, p.sequence_id as sequence_id, cp.room_name AS room_name, c.image AS image, STRING_TO_ARRAY(c.combined_participant_profile_sequence_id, ',') AS profile_sequence_ids " +
+    "SELECT p.id AS id, p.sequence_id as sequence_id, cp.room_name AS room_name, c.image AS image, c.participant_count AS participant_count, STRING_TO_ARRAY(c.combined_participant_profile_sequence_id, ',') AS profile_sequence_ids " +
             "FROM profile p " +
             "INNER JOIN chat_participant cp " +
             "ON p.sequence_id = cp.profile_sequence_id " +
@@ -25,6 +25,17 @@ interface ProfileRepository : CoroutineCrudRepository<Profile, UUID> {
             "ON cp.chat_id = c.id " +
             "WHERE p.user_id = $1")
     fun findAllWithChatsByUserId(userId: String): Flow<ProfileChatDto>
+
+    @Query(value =
+    "SELECT p.id AS id, p.sequence_id as sequence_id, cp.room_name AS room_name, c.image AS image, c.participant_count AS participant_count, STRING_TO_ARRAY(c.combined_participant_profile_sequence_id, ',') AS profile_sequence_ids " +
+            "FROM profile p " +
+            "INNER JOIN chat_participant cp " +
+            "ON p.sequence_id = cp.profile_sequence_id " +
+            "INNER JOIN chat c " +
+            "ON cp.chat_id = c.id " +
+            "WHERE p.user_id = $1 " +
+            "AND c.id = $2 ")
+    suspend fun findWithChatsByUserIdAndChatId(userId: String, chatId: UUID): ProfileChatDto?
 
     fun findAllBySequenceIdIn(sequenceIds: List<Long>): Flow<Profile>
 }

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileService.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileService.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
 
 @Service
 class ProfileService(
@@ -54,6 +55,11 @@ class ProfileService(
     fun getAllWithChatsByUserId(userId: String?): Flow<ProfileChatDto> {
         if (userId == null) throw Exception("회원 번호가 존재하지 않습니다")
         return repository.findAllWithChatsByUserId(userId)
+    }
+
+    suspend fun getWithChatsByUserIdAndChatId(userId: String?, chatId: UUID): ProfileChatDto {
+        if (userId == null) throw Exception("회원 번호가 존재하지 않습니다")
+        return repository.findWithChatsByUserIdAndChatId(userId, chatId) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원 채팅방 정보입니다")
     }
 
     /**


### PR DESCRIPTION
## 요약
- 채팅방 단일 조회 api 추가
## API
- method: get
- url: /member-service/profile/chats/{id}
- content-type: application/json
- authorization: Bearer Token
### Response
- status: 200 Ok
- body
```jsonc
{
  "id": "chat ID",
  "roomName": "참가자 방 이름",
  "image": "이미지",
  "participantCount": "참가자 수"
}
```