### PR TITLE
refactor: ProfileQueryService.kt 수정

### DIFF
--- a/src/main/kotlin/com/talk/memberService/profile/ProfileQueryService.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileQueryService.kt
@@ -1,6 +1,5 @@
 package com.talk.memberService.profile
 
-import com.talk.memberService.friend.Friend
 import com.talk.memberService.friend.FriendService
 import com.talk.memberService.friend.FriendType
 import com.talk.memberService.profile.ProfileView.Companion.profileViewBuilder
@@ -35,15 +34,13 @@ class ProfileQueryService(
      * 프로필의 채팅방을 조회한다
      * 채팅방 참가자가 이름을 설정하지 않은 경우
      * 자신의 이름을 제외한 참가자 아이디를 문자열로 생성한다 (구분자 ,)
-     * 참가자중 자신의 친구는 친구의 이름으로 문자열을 생성한다
+     * 참가자중 (일반, 추천) 친구의 이름으로 문자열을 생성한다
      */
     suspend fun getAllWithChats(userId: String?): Flow<ProfileChatDto> {
         val profile = profileService.getByUserId(userId)
-        val friends = friendService.getAllBySubjectProfileSequenceId(profile.sequenceId!!).toList()
         return profileService.getAllWithChatsByUserId(userId).map { chat ->
             if (chat.roomName != null) return@map chat
-            val roomName = chat.profileSequenceIds.minus(chat.sequenceId)
-                    .createRoomNameBySequenceIds(friends)
+            val roomName = friendService.getAllBySubjectProfileSequenceId(profile.sequenceId!!).map { it.name }.toList().plus(profile.name).joinToString(separator = ",")
             chat.copy(roomName = roomName)
         }
     }
@@ -53,16 +50,4 @@ class ProfileQueryService(
      */
     suspend fun getWithChat(userId: String?, chatId: UUID): ProfileChatDetailDto =
             profileService.getWithChatByUserIdAndChatId(userId, chatId)
-
-    private suspend fun List<Long>.createRoomNameBySequenceIds(friends: List<Friend>): String {
-        val participantFriends = friends.filter { this.contains(it.objectProfileSequenceId) }
-        val remainParticipants = this.minus(participantFriends.map { it.objectProfileSequenceId }.toSet())
-        val friendNames = participantFriends.map { it.name }
-        if (remainParticipants.isEmpty()) {
-            return friendNames.joinToString(separator = ",")
-        }
-        return profileService.getAllBySequenceIds(remainParticipants).map { it.name }.run {
-            merge(this, friendNames.asFlow())
-        }.toList().joinToString(separator = ",")
-    }
 }

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileRepository.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileRepository.kt
@@ -35,6 +35,4 @@ interface ProfileRepository : CoroutineCrudRepository<Profile, UUID> {
             "WHERE p.user_id = $1 " +
             "AND c.id = $2 ")
     suspend fun findWithChatByUserIdAndChatId(userId: String, chatId: UUID): ProfileChatDetailDto?
-
-    fun findAllBySequenceIdIn(sequenceIds: List<Long>): Flow<Profile>
 }

--- a/src/main/kotlin/com/talk/memberService/profile/ProfileService.kt
+++ b/src/main/kotlin/com/talk/memberService/profile/ProfileService.kt
@@ -55,10 +55,4 @@ class ProfileService(
         if (userId == null) throw Exception("회원 번호가 존재하지 않습니다")
         return repository.findWithChatByUserIdAndChatId(userId, chatId) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원 채팅방 정보입니다")
     }
-
-    /**
-     * 프로필 순차 ID 기준 리스트 조회
-     */
-    fun getAllBySequenceIds(sequenceIds: List<Long>): Flow<Profile> =
-            repository.findAllBySequenceIdIn(sequenceIds)
 }

--- a/src/test/kotlin/com/talk/memberService/profile/api/ProfileChatViewsApiTests.kt
+++ b/src/test/kotlin/com/talk/memberService/profile/api/ProfileChatViewsApiTests.kt
@@ -101,55 +101,6 @@ class ProfileChatViewsApiTests(
             }
         }
 
-        When("채팅방 참가자들이 친구가 없고, 방 이름 설정 안한 경우") {
-            beforeTest {
-                profileRepository.deleteAll()
-                friendRepository.deleteAll()
-                chatRepository.deleteAll()
-                chatParticipantRepository.deleteAll()
-                val profile1 = profile {
-                    this.userId = Oauth2Constants.SUBJECT
-                    this.sequenceId = 1
-                    this.email = "user@test"
-                    this.name = "user"
-                }.run { profileRepository.save(this) }
-
-                val profile2 = profile {
-                    this.userId = "b"
-                    this.sequenceId = 2
-                    this.email = "b@test"
-                    this.name = "b"
-                }.run { profileRepository.save(this) }
-
-                val profile3 = profile {
-                    this.userId = "c"
-                    this.sequenceId = 3
-                    this.email = "c@test"
-                    this.name = "c"
-                }.run { profileRepository.save(this) }
-
-                val profile4 = profile {
-                    this.userId = "d"
-                    this.sequenceId = 4
-                    this.email = "d@test"
-                    this.name = "d"
-                }.run { profileRepository.save(this) }
-
-                createChats(listOf(profile1, profile2, profile3))
-                createChats(listOf(profile1, profile3, profile4))
-                createChats(listOf(profile2, profile3))
-            }
-            Then("status: 200 Ok, 방 이름은 ',' 으로 구분된다") {
-                val exchanged = request().exchange()
-                exchanged.expectStatus().isOk
-                exchanged.expectBodyList(ProfileChatView::class.java).returnResult().responseBody.shouldNotBeNull()
-                        .should { chats ->
-                            chats.filter { it.roomName.contains(",") }.size shouldBe 2
-                        }
-            }
-        }
-
-
         When("채팅방 참가자들이 친구가 있고, 방 이름 설정 안한 경우") {
             beforeTest {
                 profileRepository.deleteAll()


### PR DESCRIPTION
## 요약
### AS-IS
- 프로필 - 채팅방리스트 조회시 친구의 이름 + 프로필 이름을 합쳐서 채팅방 이름을 만든다
- 친구로 등록되지 않은 경우, 참가자의 프로필 조회후, 이름을 가져와서 채팅방 이름을 만든다
###  TO-BE
- 상대방이 친구를 등록하면, 추천 친구로 자동 등록되기 떄문에,  
- 프로필 - 채팅방리스트 조회시 친구의 이름 + 자신의 프로필 이름을 합쳐서 채팅방 이름을 만든다
